### PR TITLE
Added basic callbacks to the list

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -29,6 +29,8 @@ struct list_s {
     void  *(*mem_alloc)  (size_t size);
     void  *(*mem_calloc) (size_t blocks, size_t size);
     void   (*mem_free)   (void *block);
+    void   (*on_add)     (List *list, void *data);
+    void   (*on_remove)  (List *list);
 };
 
 static void *unlink              (List *list, Node *node);
@@ -136,6 +138,35 @@ bool list_destroy_free(List *list)
 }
 
 /**
+ * Sets the on_add callback for list. The function passed to this function
+ * will be called when there are single elements added to the list.
+ *
+ * @param[in] list the list which should recive the callback
+ * @param[in] on_add the callback
+ */
+
+void list_set_add_callback (List *list, void (*on_add) (List *list, void *data))
+{
+  if(list)
+    list->on_add = on_add;
+}
+
+/**
+ * Sets the on_remove callback for list. The function passed to this function
+ * will be called when there are single elements removed from the list.
+ *
+ * @param[in] list the list which should recive the callback
+ * @param[in] on_remove the callback
+ */
+
+void list_set_remove_callback(List *list, void (*on_remove) (List *list))
+{
+  if(list)
+    list->on_remove = on_remove;
+}
+
+
+/**
  * Adds a new element to the list. The element is appended to the list making it
  * the last element in the list. This function returns false if the memory
  * allocation for the new element fails.
@@ -178,6 +209,10 @@ enum cc_stat list_add_first(List *list, void *element)
         list->head = node;
     }
     list->size++;
+
+    if(list->on_add)
+      list->on_add(list, element);
+
     return CC_OK;
 }
 
@@ -209,6 +244,10 @@ enum cc_stat list_add_last(List *list, void *element)
         list->tail = node;
     }
     list->size++;
+
+    if(list->on_add)
+      list->on_add(list, element);
+
     return CC_OK;
 }
 
@@ -246,6 +285,9 @@ enum cc_stat list_add_at(List *list, void *element, size_t index)
         list->head = new;
 
     list->size++;
+
+    if(list->on_add)
+      list->on_add(list, element);
 
     return CC_OK;
 }
@@ -295,6 +337,7 @@ static enum cc_stat add_all_to_empty(List *list1, List *list2)
     list1->head = head;
     list1->tail = tail;
     list1->size = list2->size;
+
     return CC_OK;
 }
 
@@ -522,6 +565,10 @@ enum cc_stat list_remove(List *list, void *element, void **out)
         *out = node->data;
 
     unlink(list, node);
+
+    if(list->on_remove)
+      list->on_remove(list);
+
     return CC_OK;
 }
 
@@ -550,6 +597,10 @@ enum cc_stat list_remove_at(List *list, size_t index, void **out)
         *out = node->data;
 
     unlink(list, node);
+
+    if(list->on_remove)
+      list->on_remove(list);
+
     return CC_OK;
 }
 
@@ -570,6 +621,9 @@ enum cc_stat list_remove_first(List *list, void **out)
 
     if (out)
         *out = e;
+
+    if(list->on_remove)
+      list->on_remove(list);
 
     return CC_OK;
 }
@@ -592,6 +646,9 @@ enum cc_stat list_remove_last(List *list, void **out)
     if (out)
         *out = node->data;
 
+    if(list->on_remove)
+      list->on_remove(list);
+
     return CC_OK;
 }
 
@@ -611,6 +668,10 @@ enum cc_stat list_remove_all(List *list)
     if (unlinked) {
         list->head = NULL;
         list->tail = NULL;
+
+        if(list->on_remove)
+          list->on_remove(list);
+
         return CC_OK;
     }
     return CC_ERR_VALUE_NOT_FOUND;
@@ -639,6 +700,10 @@ enum cc_stat list_remove_all_free(List *list)
     if (unlinked) {
         list->head = NULL;
         list->tail = NULL;
+
+        if(list->on_remove)
+          list->on_remove(list);
+
         return CC_OK;
     }
     return CC_ERR_VALUE_NOT_FOUND;
@@ -1220,6 +1285,10 @@ enum cc_stat list_iter_remove(ListIter *iter, void **out)
 
     if (out)
         *out = e;
+
+    if(iter->list->on_remove)
+      iter->list->on_remove(iter->list);
+
     return CC_OK;
 }
 
@@ -1249,6 +1318,9 @@ enum cc_stat list_iter_add(ListIter *iter, void *element)
 
     iter->list->size++;
     iter->index++;
+
+    if(iter->list->on_add)
+      iter->list->on_add(iter->list, element);
 
     return CC_OK;
 }

--- a/src/list.h
+++ b/src/list.h
@@ -100,6 +100,10 @@ enum cc_stat  list_new_conf        (const ListConf const* conf, List **list);
 bool          list_destroy         (List *list);
 bool          list_destroy_free    (List *list);
 
+void          list_set_add_callback   (List *list, void (*on_add) (List *list, void *data));
+void          list_set_remove_callback(List *list, void (*on_remove) (List *list));
+
+
 enum cc_stat  list_splice          (List *list1, List *list2);
 enum cc_stat  list_splice_at       (List *list, List *list2, size_t index);
 


### PR DESCRIPTION
This implementation is similar to what you suggested in #10 

It can only trigger the callback if you add a single element to the list. Any ideas how we should do this with `add_all` or `add_all_at`?

Signed-off-by: Marius Messerschmidt marius.messerschmidt@googlemail.com
