### PR TITLE
Fix clang -Wduplicate-decl-specifier warning

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -61,7 +61,7 @@ enum cc_stat array_new(Array **out)
  *
  * @return a new array if the allocation was successful, or NULL if not.
  */
-enum cc_stat array_new_conf(const ArrayConf const* conf, Array **out)
+enum cc_stat array_new_conf(ArrayConf const * const conf, Array **out)
 {
     float ex;
 

--- a/src/array.h
+++ b/src/array.h
@@ -85,7 +85,7 @@ typedef struct array_iter_s {
 } ArrayIter;
 
 enum cc_stat  array_new             (Array **out);
-enum cc_stat  array_new_conf        (const ArrayConf const* conf, Array **out);
+enum cc_stat  array_new_conf        (ArrayConf const * const conf, Array **out);
 void          array_conf_init       (ArrayConf *conf);
 
 void          array_destroy         (Array *ar);

--- a/src/deque.c
+++ b/src/deque.c
@@ -62,7 +62,7 @@ enum cc_stat deque_new(Deque **deque)
  *
  * @return a new deque if the allocation was successful, or NULL if not.
  */
-enum cc_stat deque_new_conf(const DequeConf const* conf, Deque **d)
+enum cc_stat deque_new_conf(DequeConf const * const conf, Deque **d)
 {
     Deque *deque = conf->mem_calloc(1, sizeof(Deque));
 

--- a/src/deque.h
+++ b/src/deque.h
@@ -73,7 +73,7 @@ typedef struct deque_iter_s {
 } DequeIter;
 
 enum cc_stat  deque_new             (Deque **deque);
-enum cc_stat  deque_new_conf        (const DequeConf const* conf, Deque **deque);
+enum cc_stat  deque_new_conf        (DequeConf const * const conf, Deque **deque);
 void          deque_conf_init       (DequeConf *conf);
 
 void          deque_destroy         (Deque *deque);

--- a/src/hashset.c
+++ b/src/hashset.c
@@ -62,7 +62,7 @@ enum cc_stat hashset_new(HashSet **hs)
  *
  * @return a new empty HashSet
  */
-enum cc_stat hashset_new_conf(const HashSetConf const* conf, HashSet **hs)
+enum cc_stat hashset_new_conf(HashSetConf const * const conf, HashSet **hs)
 {
     HashSet *set = conf->mem_calloc(1, sizeof(HashSet));
 

--- a/src/hashset.h
+++ b/src/hashset.h
@@ -56,7 +56,7 @@ typedef struct hashset_iter_s {
 void          hashset_conf_init     (HashSetConf *conf);
 
 enum cc_stat  hashset_new           (HashSet **hs);
-enum cc_stat  hashset_new_conf      (const HashSetConf const* conf, HashSet **hs);
+enum cc_stat  hashset_new_conf      (HashSetConf const * const conf, HashSet **hs);
 void          hashset_destroy       (HashSet *set);
 
 enum cc_stat  hashset_add           (HashSet *set, void *element);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -74,7 +74,7 @@ enum cc_stat hashtable_new(HashTable **out)
  *
  * @return a new HashTable or NULL if the memory allocation fails.
  */
-enum cc_stat hashtable_new_conf(const HashTableConf const* conf, HashTable **out)
+enum cc_stat hashtable_new_conf(HashTableConf const * const conf, HashTable **out)
 {
     HashTable *table = conf->mem_calloc(1, sizeof(HashTable));
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -146,7 +146,7 @@ typedef struct hashtable_conf_s {
 
 void          hashtable_conf_init       (HashTableConf *conf);
 enum cc_stat  hashtable_new             (HashTable **out);
-enum cc_stat  hashtable_new_conf        (const HashTableConf const* conf, HashTable **out);
+enum cc_stat  hashtable_new_conf        (HashTableConf const * const conf, HashTable **out);
 
 void          hashtable_destroy         (HashTable *table);
 enum cc_stat  hashtable_add             (HashTable *table, void *key, void *val);

--- a/src/list.c
+++ b/src/list.c
@@ -82,7 +82,7 @@ enum cc_stat list_new(List **out)
  *
  * @return a new list if the allocation was successful, or NULL if not.
  */
-enum cc_stat list_new_conf(const ListConf const* conf, List **out)
+enum cc_stat list_new_conf(ListConf const * const conf, List **out)
 {
     List *list = conf->mem_calloc(1, sizeof(List));
 

--- a/src/list.h
+++ b/src/list.h
@@ -96,7 +96,7 @@ typedef struct list_conf_s {
 
 void          list_conf_init       (ListConf *conf);
 enum cc_stat  list_new             (List **list);
-enum cc_stat  list_new_conf        (const ListConf const* conf, List **list);
+enum cc_stat  list_new_conf        (ListConf const * const conf, List **list);
 bool          list_destroy         (List *list);
 bool          list_destroy_free    (List *list);
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -60,7 +60,7 @@ enum cc_stat queue_new(Queue **queue)
  *
  * @return a new queue if the allocation was successful, or NULL.
  */
-enum cc_stat queue_new_conf(const QueueConf const* conf, Queue **q)
+enum cc_stat queue_new_conf(QueueConf const * const conf, Queue **q)
 {
     Queue *queue = conf->mem_calloc(1, sizeof(Queue));
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -54,7 +54,7 @@ typedef struct queue_iter_s {
 
 void          queue_conf_init    (QueueConf *conf);
 enum cc_stat  queue_new          (Queue **q);
-enum cc_stat  queue_new_conf     (const QueueConf const* conf, Queue **q);
+enum cc_stat  queue_new_conf     (QueueConf const * const conf, Queue **q);
 void          queue_destroy      (Queue *queue);
 void          queue_destroy_free (Queue *queue);
 

--- a/src/slist.c
+++ b/src/slist.c
@@ -73,7 +73,7 @@ enum cc_stat slist_new(SList **out)
  *
  * @return a new SList if the allocation was successful, or NULL if not.
  */
-enum cc_stat slist_new_conf(const SListConf const* conf, SList **out)
+enum cc_stat slist_new_conf(SListConf const * const conf, SList **out)
 {
     SList *list = conf->mem_calloc(1, sizeof(SList));
 

--- a/src/slist.h
+++ b/src/slist.h
@@ -85,7 +85,7 @@ typedef struct slist_conf_s {
 
 void          slist_conf_init       (SListConf *conf);
 enum cc_stat  slist_new             (SList **list);
-enum cc_stat  slist_new_conf        (const SListConf const* conf, SList **list);
+enum cc_stat  slist_new_conf        (SListConf const * const conf, SList **list);
 bool          slist_destroy         (SList *list);
 bool          slist_destroy_free    (SList *list);
 

--- a/src/stack.c
+++ b/src/stack.c
@@ -61,7 +61,7 @@ enum cc_stat stack_new(Stack **out)
  *
  * @return a new empty stack, or NULL if the allocation fails
  */
-enum cc_stat stack_new_conf(const StackConf const* conf, Stack **out)
+enum cc_stat stack_new_conf(StackConf const * const conf, Stack **out)
 {
     Stack *stack = conf->mem_calloc(1, sizeof(Stack));
 

--- a/src/stack.h
+++ b/src/stack.h
@@ -37,7 +37,7 @@ typedef ArrayConf StackConf;
 
 void          stack_conf_init   (StackConf *conf);
 enum cc_stat  stack_new         (Stack **out);
-enum cc_stat  stack_new_conf    (const StackConf const* conf, Stack **out);
+enum cc_stat  stack_new_conf    (StackConf const * const conf, Stack **out);
 void          stack_destroy     (Stack *stack);
 void          stack_destroy_free(Stack *stack);
 

--- a/src/treeset.c
+++ b/src/treeset.c
@@ -65,7 +65,7 @@ enum cc_stat treeset_new(int (*cmp) (void*, void*), TreeSet **set)
  *
  * @return a new empty TreeSet
  */
-enum cc_stat treeset_new_conf(const TreeSetConf const* conf, TreeSet **tset)
+enum cc_stat treeset_new_conf(TreeSetConf const * const conf, TreeSet **tset)
 {
     TreeSet *set = conf->mem_calloc(1, sizeof(TreeSet));
 

--- a/src/treeset.h
+++ b/src/treeset.h
@@ -59,7 +59,7 @@ typedef struct treeset_iter_s {
 
 void          treeset_conf_init        (TreeSetConf *conf);
 enum cc_stat  treeset_new              (int (*cmp) (void*, void*), TreeSet **set);
-enum cc_stat  treeset_new_conf         (const TreeSetConf const* conf, TreeSet **set);
+enum cc_stat  treeset_new_conf         (TreeSetConf const * const conf, TreeSet **set);
 
 void          treeset_destroy          (TreeSet *set);
 

--- a/src/treetable.c
+++ b/src/treetable.c
@@ -91,7 +91,7 @@ enum cc_stat treetable_new(int (*cmp) (void *, void *), TreeTable **tt)
  *
  * @return a new TreeTable or NULL if the memory allocation fails.
  */
-enum cc_stat treetable_new_conf(const TreeTableConf const* conf, TreeTable **tt)
+enum cc_stat treetable_new_conf(TreeTableConf const * const conf, TreeTable **tt)
 {
     TreeTable *table = conf->mem_calloc(1, sizeof(TreeTable));
 

--- a/src/treetable.h
+++ b/src/treetable.h
@@ -117,7 +117,7 @@ typedef struct treetable_conf_s {
 
 void          treetable_conf_init        (TreeTableConf *conf);
 enum cc_stat  treetable_new              (int (*cmp) (void *, void *), TreeTable **tt);
-enum cc_stat  treetable_new_conf         (const TreeTableConf const *conf, TreeTable **tt);
+enum cc_stat  treetable_new_conf         (TreeTableConf const * const conf, TreeTable **tt);
 
 void          treetable_destroy          (TreeTable *table);
 enum cc_stat  treetable_add              (TreeTable *table, void *key, void *val);


### PR DESCRIPTION
"Const pointer to const value" should be written according to C convention.