### PR TITLE
Made the include guards unique, or, rather unique.

### DIFF
--- a/src/array.h
+++ b/src/array.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__ARRAY_H__
-#define __COLLECTIONS_C__ARRAY_H__
+#ifndef COLLECTIONS_C__ARRAY_H
+#define COLLECTIONS_C__ARRAY_H
 
 #include "common.h"
 
@@ -129,4 +129,4 @@ size_t        array_iter_index      (ArrayIter *iter);
 
 const void* const* array_get_buffer(Array *ar);
 
-#endif /* __COLLECTIONS_C__ARRAY_H__ */
+#endif /* COLLECTIONS_C__ARRAY_H */

--- a/src/array.h
+++ b/src/array.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARRAY_H_
-#define ARRAY_H_
+#ifndef __COLLECTIONS_C__ARRAY_H__
+#define __COLLECTIONS_C__ARRAY_H__
 
 #include "common.h"
 
@@ -129,4 +129,4 @@ size_t        array_iter_index      (ArrayIter *iter);
 
 const void* const* array_get_buffer(Array *ar);
 
-#endif /* ARRAY_H_ */
+#endif /* __COLLECTIONS_C__ARRAY_H__ */

--- a/src/common.h
+++ b/src/common.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef COMMON_H_
-#define COMMON_H_
+#ifndef __COLLECTIONS_C__COMMON_H_
+#define __COLLECTIONS_C__COMMON_H_
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -62,4 +62,4 @@ enum cc_stat {
 #endif /* _MSC_VER */
 
 
-#endif /* COMMON_H_ */
+#endif /* __COLLECTIONS_C__COMMON_H_ */

--- a/src/common.h
+++ b/src/common.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__COMMON_H_
-#define __COLLECTIONS_C__COMMON_H_
+#ifndef COLLECTIONS_C__COMMON_H
+#define COLLECTIONS_C__COMMON_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -62,4 +62,4 @@ enum cc_stat {
 #endif /* _MSC_VER */
 
 
-#endif /* __COLLECTIONS_C__COMMON_H_ */
+#endif /* COLLECTIONS_C__COMMON_H */

--- a/src/deque.h
+++ b/src/deque.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__DEQUE_H__
-#define __COLLECTIONS_C__DEQUE_H__
+#ifndef COLLECTIONS_C__DEQUE_H
+#define COLLECTIONS_C__DEQUE_H
 
 #include "common.h"
 
@@ -119,4 +119,4 @@ size_t        deque_iter_index      (DequeIter *iter);
 
 const void* const* deque_get_buffer(Deque *deque);
 
-#endif /* __COLLECTIONS_C__DEQUE_H__ */
+#endif /* COLLECTIONS_C__DEQUE_H */

--- a/src/deque.h
+++ b/src/deque.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DEQUE_H_
-#define DEQUE_H_
+#ifndef __COLLECTIONS_C__DEQUE_H__
+#define __COLLECTIONS_C__DEQUE_H__
 
 #include "common.h"
 
@@ -119,4 +119,4 @@ size_t        deque_iter_index      (DequeIter *iter);
 
 const void* const* deque_get_buffer(Deque *deque);
 
-#endif /* DEQUE_H_ */
+#endif /* __COLLECTIONS_C__DEQUE_H__ */

--- a/src/hashset.h
+++ b/src/hashset.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HASHSET_H_
-#define HASHSET_H_
+#ifndef __COLLECTIONS_C__HASHSET_H__
+#define __COLLECTIONS_C__HASHSET_H__
 
 #include "common.h"
 #include "hashtable.h"
@@ -73,4 +73,4 @@ void          hashset_iter_init     (HashSetIter *iter, HashSet *set);
 enum cc_stat  hashset_iter_next     (HashSetIter *iter, void **out);
 enum cc_stat  hashset_iter_remove   (HashSetIter *iter, void **out);
 
-#endif /* HASHSET_H_ */
+#endif /* __COLLECTIONS_C__HASHSET_H__ */

--- a/src/hashset.h
+++ b/src/hashset.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__HASHSET_H__
-#define __COLLECTIONS_C__HASHSET_H__
+#ifndef COLLECTIONS_C__HASHSET_H
+#define COLLECTIONS_C__HASHSET_H
 
 #include "common.h"
 #include "hashtable.h"
@@ -73,4 +73,4 @@ void          hashset_iter_init     (HashSetIter *iter, HashSet *set);
 enum cc_stat  hashset_iter_next     (HashSetIter *iter, void **out);
 enum cc_stat  hashset_iter_remove   (HashSetIter *iter, void **out);
 
-#endif /* __COLLECTIONS_C__HASHSET_H__ */
+#endif /* COLLECTIONS_C__HASHSET_H */

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -18,8 +18,8 @@
  * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__HASHTABLE_H__
-#define __COLLECTIONS_C__HASHTABLE_H__
+#ifndef COLLECTIONS_C__HASHTABLE_H
+#define COLLECTIONS_C__HASHTABLE_H
 
 #include "array.h"
 
@@ -195,4 +195,4 @@ enum cc_stat  hashtable_iter_remove     (HashTableIter *iter, void **out);
 #define POINTER_HASH hashtable_hash_ptr
 
 
-#endif /* __COLLECTIONS_C__HASHTABLE_H__ */
+#endif /* COLLECTIONS_C__HASHTABLE_H */

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -18,8 +18,8 @@
  * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HASHTABLE_H
-#define HASHTABLE_H
+#ifndef __COLLECTIONS_C__HASHTABLE_H__
+#define __COLLECTIONS_C__HASHTABLE_H__
 
 #include "array.h"
 
@@ -195,4 +195,4 @@ enum cc_stat  hashtable_iter_remove     (HashTableIter *iter, void **out);
 #define POINTER_HASH hashtable_hash_ptr
 
 
-#endif /* __HASHTABLE_H__ */
+#endif /* __COLLECTIONS_C__HASHTABLE_H__ */

--- a/src/list.h
+++ b/src/list.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIST_H_
-#define LIST_H_
+#ifndef __COLLECTIONS_C__LIST_H__
+#define __COLLECTIONS_C__LIST_H__
 
 #include "common.h"
 
@@ -153,4 +153,4 @@ enum cc_stat  list_diter_replace   (ListIter *iter, void *element, void **out);
 size_t        list_diter_index     (ListIter *iter);
 enum cc_stat  list_diter_next      (ListIter *iter, void **out);
 
-#endif /* LIST_H_ */
+#endif /* __COLLECTIONS_C__LIST_H__ */

--- a/src/list.h
+++ b/src/list.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__LIST_H__
-#define __COLLECTIONS_C__LIST_H__
+#ifndef COLLECTIONS_C__LIST_H
+#define COLLECTIONS_C__LIST_H
 
 #include "common.h"
 
@@ -153,4 +153,4 @@ enum cc_stat  list_diter_replace   (ListIter *iter, void *element, void **out);
 size_t        list_diter_index     (ListIter *iter);
 enum cc_stat  list_diter_next      (ListIter *iter, void **out);
 
-#endif /* __COLLECTIONS_C__LIST_H__ */
+#endif /* COLLECTIONS_C__LIST_H */

--- a/src/queue.h
+++ b/src/queue.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef QUEUE_H_
-#define QUEUE_H_
+#ifndef __COLLECTIONS_C__QUEUE_H__
+#define __COLLECTIONS_C__QUEUE_H__
 
 #include "common.h"
 #include "deque.h"
@@ -69,4 +69,4 @@ void          queue_iter_init    (QueueIter *iter, Queue *queue);
 enum cc_stat  queue_iter_next    (QueueIter *iter, void **out);
 enum cc_stat  queue_iter_replace (QueueIter *iter, void *replacement, void **out);
 
-#endif /* QUEUE_H_ */
+#endif /* __COLLECTIONS_C__QUEUE_H__ */

--- a/src/queue.h
+++ b/src/queue.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__QUEUE_H__
-#define __COLLECTIONS_C__QUEUE_H__
+#ifndef COLLECTIONS_C__QUEUE_H
+#define COLLECTIONS_C__QUEUE_H
 
 #include "common.h"
 #include "deque.h"
@@ -69,4 +69,4 @@ void          queue_iter_init    (QueueIter *iter, Queue *queue);
 enum cc_stat  queue_iter_next    (QueueIter *iter, void **out);
 enum cc_stat  queue_iter_replace (QueueIter *iter, void *replacement, void **out);
 
-#endif /* __COLLECTIONS_C__QUEUE_H__ */
+#endif /* COLLECTIONS_C__QUEUE_H */

--- a/src/slist.h
+++ b/src/slist.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__SLIST_H__
-#define __COLLECTIONS_C__SLIST_H__
+#ifndef COLLECTIONS_C__SLIST_H
+#define COLLECTIONS_C__SLIST_H
 
 #include "common.h"
 
@@ -134,4 +134,4 @@ enum cc_stat  slist_iter_replace    (SListIter *iter, void *element, void **out)
 enum cc_stat  slist_iter_next       (SListIter *iter, void **out);
 size_t        slist_iter_index      (SListIter *iter);
 
-#endif /* __COLLECTIONS_C__SLIST_H__ */
+#endif /* COLLECTIONS_C__SLIST_H */

--- a/src/slist.h
+++ b/src/slist.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SLIST_H_
-#define SLIST_H_
+#ifndef __COLLECTIONS_C__SLIST_H__
+#define __COLLECTIONS_C__SLIST_H__
 
 #include "common.h"
 
@@ -134,4 +134,4 @@ enum cc_stat  slist_iter_replace    (SListIter *iter, void *element, void **out)
 enum cc_stat  slist_iter_next       (SListIter *iter, void **out);
 size_t        slist_iter_index      (SListIter *iter);
 
-#endif /* SLIST_H_ */
+#endif /* __COLLECTIONS_C__SLIST_H__ */

--- a/src/stack.h
+++ b/src/stack.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef STACK_H_
-#define STACK_H_
+#ifndef __COLLECTIONS_C__STACK_H__
+#define __COLLECTIONS_C__STACK_H__
 
 #include "common.h"
 #include "array.h"
@@ -48,4 +48,4 @@ enum cc_stat  stack_pop         (Stack *stack, void **out);
 size_t        stack_size        (Stack *stack);
 void          stack_map         (Stack *stack, void (*fn) (void *));
 
-#endif /* STACK_H_ */
+#endif /* __COLLECTIONS_C__STACK_H__ */

--- a/src/stack.h
+++ b/src/stack.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__STACK_H__
-#define __COLLECTIONS_C__STACK_H__
+#ifndef COLLECTIONS_C__STACK_H
+#define COLLECTIONS_C__STACK_H
 
 #include "common.h"
 #include "array.h"
@@ -48,4 +48,4 @@ enum cc_stat  stack_pop         (Stack *stack, void **out);
 size_t        stack_size        (Stack *stack);
 void          stack_map         (Stack *stack, void (*fn) (void *));
 
-#endif /* __COLLECTIONS_C__STACK_H__ */
+#endif /* COLLECTIONS_C__STACK_H */

--- a/src/treeset.h
+++ b/src/treeset.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREESET_H
-#define TREESET_H
+#ifndef __COLLECTIONS_C__TREESET_H__
+#define __COLLECTIONS_C__TREESET_H__
 
 #include "common.h"
 #include "treetable.h"
@@ -81,4 +81,4 @@ void          treeset_iter_init        (TreeSetIter *iter, TreeSet *set);
 void          treeset_iter_next        (TreeSetIter *iter, void **element);
 void          treeset_iter_remove      (TreeSetIter *iter);
 
-#endif
+#endif /* __COLLECTIONS_C__TREESET_H__*/

--- a/src/treeset.h
+++ b/src/treeset.h
@@ -18,8 +18,8 @@
  * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__TREESET_H__
-#define __COLLECTIONS_C__TREESET_H__
+#ifndef COLLECTIONS_C__TREESET_H
+#define COLLECTIONS_C__TREESET_H
 
 #include "common.h"
 #include "treetable.h"
@@ -81,4 +81,4 @@ void          treeset_iter_init        (TreeSetIter *iter, TreeSet *set);
 void          treeset_iter_next        (TreeSetIter *iter, void **element);
 void          treeset_iter_remove      (TreeSetIter *iter);
 
-#endif /* __COLLECTIONS_C__TREESET_H__*/
+#endif /* COLLECTIONS_C__TREESET_H */

--- a/src/treetable.h
+++ b/src/treetable.h
@@ -18,8 +18,8 @@
  * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREETABLE_H
-#define TREETABLE_H
+#ifndef __COLLECTIONS_C__TREETABLE_H__
+#define __COLLECTIONS_C__TREETABLE_H__
 
 #include "common.h"
 
@@ -154,6 +154,6 @@ void          treetable_iter_remove      (TreeTableIter *iter);
 #define RB_ERROR_OK              4
 
 int treetable_assert_rb_rules(TreeTable *table);
-#endif
+#endif /* DEBUG */
 
-#endif
+#endif /* __COLLECTIONS_C__TREETABLE_H__ */

--- a/src/treetable.h
+++ b/src/treetable.h
@@ -18,8 +18,8 @@
  * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COLLECTIONS_C__TREETABLE_H__
-#define __COLLECTIONS_C__TREETABLE_H__
+#ifndef COLLECTIONS_C__TREETABLE_H
+#define COLLECTIONS_C__TREETABLE_H
 
 #include "common.h"
 
@@ -156,4 +156,4 @@ void          treetable_iter_remove      (TreeTableIter *iter);
 int treetable_assert_rb_rules(TreeTable *table);
 #endif /* DEBUG */
 
-#endif /* __COLLECTIONS_C__TREETABLE_H__ */
+#endif /* COLLECTIONS_C__TREETABLE_H */


### PR DESCRIPTION
I read the suggestions in the discussion, and implemented making the include guards unique. Sure, they are long, and pedantic, but I highly doubt anyone is going to be using those names.