### PR TITLE
deque_iter_remove: do not return garbage

### DIFF
--- a/src/deque.c
+++ b/src/deque.c
@@ -933,11 +933,11 @@ enum cc_stat deque_iter_remove(DequeIter *iter, void **out)
 {
     void *rm;
     enum cc_stat status = deque_remove_at(iter->deque, iter->index, &rm);
-    if (status == CC_OK)
+    if (status == CC_OK) {
         iter->index--;
-
-    if (out)
-        *out = rm;
+        if (out)
+            *out = rm;
+    }
 
     return status;
 }


### PR DESCRIPTION
Garbage may be returned through `out` if `deque_remove_at()` fails.
Suggest modifying `*out` only if `deque_remove_at()` succeeds (returns OK).