### PR TITLE
Fix *_zip_iter_remove() tests

### DIFF
--- a/test/array_test.c
+++ b/test/array_test.c
@@ -831,7 +831,7 @@ void test_array_zip_iter_remove()
         if (strcmp((char*) e1, "b") == 0)
             array_zip_iter_remove(&zip, &r1, &r2);
     }
-    cc_assert(r1 == "b" && r2 == "f",
+    cc_assert(strcmp((char*) r1, "b") == 0 && strcmp((char*) r2, "f") == 0,
               cc_msg("array_zip_iter_remove: Removed elements don't match expected ones"));
 
     cc_assert(array_contains(a1, "b") == 0,

--- a/test/deque_test.c
+++ b/test/deque_test.c
@@ -1123,7 +1123,7 @@ void test_deque_zip_iter_remove()
         if (strcmp((char*) e1, "b") == 0)
             deque_zip_iter_remove(&zip, &r1, &r2);
     }
-    cc_assert(r1 == "b" && r2 == "f",
+    cc_assert(strcmp((char*) r1, "b") == 0 && strcmp((char*) r2, "f") == 0,
               cc_msg("deque_zip_iter_remove: Removed elements don't match expected ones"));
 
     cc_assert(deque_contains(d1, "b") == 0,

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -1373,7 +1373,7 @@ void test_list_zip_iter_remove()
         if (strcmp((char*) e1, "b") == 0)
             list_zip_iter_remove(&zip, &r1, &r2);
     }
-    cc_assert(r1 == "b" && r2 == "f",
+    cc_assert(strcmp((char*) r1, "b") == 0 && strcmp((char*) r2, "f") == 0,
               cc_msg("list_zip_iter_remove: Removed elements don't match expected ones"));
 
     cc_assert(list_contains(a1, "b") == 0,

--- a/test/slist_test.c
+++ b/test/slist_test.c
@@ -1164,7 +1164,7 @@ void test_slist_zip_iter_remove()
             slist_zip_iter_remove(&zip, &r1, &r2);
     }
 
-    cc_assert(r1 == "b" && r2 == "f",
+    cc_assert(strcmp((char*) r1, "b") == 0 && strcmp((char*) r2, "f") == 0,
               cc_msg("slist_zip_iter_remove: Removed elements don't match expected ones"));
 
     cc_assert(slist_contains(a1, "b") == 0,


### PR DESCRIPTION
Use strcmp() to compare strings.