### PR TITLE
Added missing semicolon to HashTable example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The source of the documentation can be found [here](https://github.com/srdja/cc-
 ```c
 
 // Crate a new table
-HashTable *table
+HashTable *table;
 if (hashtable_new(&table) != CC_OK) {
     // something went wrong
     ...


### PR DESCRIPTION
Hi! Thanks for this awesome library!

I was browsing examples and found out that one semicolon is missing. Thanks again! 😄 