### PR TITLE
remove the usage of cc_comp_ptr everywhere

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -729,7 +729,13 @@ enum cc_stat array_trim_capacity(Array *ar)
  */
 size_t array_contains(Array *ar, void *element)
 {
-    return array_contains_value(ar, element, cc_common_cmp_ptr);
+    size_t o = 0;
+    size_t i;
+    for (i = 0; i < ar->size; i++) {
+        if (ar->buffer[i] == element)
+            o++;
+    }
+    return o;
 }
 
 /**

--- a/src/common.c
+++ b/src/common.c
@@ -34,20 +34,3 @@ int cc_common_cmp_str(const void *str1, const void *str2)
 {
     return strcmp((const char*) str1, (const char*) str2);
 }
-
-/**
- * Pointer comparator function.
- *
- * @param[in] ptr1 first pointer
- * @param[in] ptr2 second pointer
- *
- * @return
- */
-int cc_common_cmp_ptr(const void *ptr1, const void *ptr2)
-{
-    if (ptr1 < ptr2)
-        return -1;
-    else if (ptr1 > ptr2)
-        return 1;
-    return 0;
-}

--- a/src/deque.c
+++ b/src/deque.c
@@ -709,7 +709,15 @@ void deque_reverse(Deque *deque)
  */
 size_t deque_contains(Deque const * const deque, const void *element)
 {
-    return deque_contains_value(deque, element, cc_common_cmp_ptr);
+    size_t i;
+    size_t o = 0;
+
+    for (i = 0; i < deque->size; i++) {
+        size_t p = (deque->first + i) & (deque->capacity - 1);
+        if (deque->buffer[p] == element)
+            o++;
+    }
+    return o;
 }
 
 /**

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -63,11 +63,7 @@ enum cc_stat {
 
 
 int cc_common_cmp_str(const void *key1, const void *key2);
-int cc_common_cmp_ptr(const void *key1, const void *key2);
-
 
 #define CC_CMP_STRING  cc_common_cmp_str
-#define CC_CMP_POINTER cc_common_cmp_ptr
-
 
 #endif /* COLLECTIONS_C_COMMON_H */

--- a/src/list.c
+++ b/src/list.c
@@ -954,7 +954,15 @@ enum cc_stat list_to_array(List *list, void ***out)
  */
 size_t list_contains(List *list, void *element)
 {
-    return list_contains_value(list, element, cc_common_cmp_ptr);
+    Node *node = list->head;
+    size_t e_count = 0;
+
+    while (node) {
+        if (node->data == element)
+            e_count++;
+        node = node->next;
+    }
+    return e_count;
 }
 
 /**
@@ -1995,7 +2003,7 @@ static Node *get_node(List *list, void *element)
 {
     Node *node = list->head;
     while (node) {
-        if (cc_common_cmp_ptr(node->data, element) == 0)
+        if (node->data == element)
             return node;
         node = node->next;
     }

--- a/src/slist.c
+++ b/src/slist.c
@@ -903,7 +903,15 @@ enum cc_stat slist_copy_deep(SList *list, void *(*cp) (void*), SList **out)
  */
 size_t slist_contains(SList *list, void *element)
 {
-    return slist_contains_value(list, element, cc_common_cmp_ptr);
+    SNode *node = list->head;
+    size_t e_count = 0;
+
+    while (node) {
+        if (node->data == element)
+            e_count++;
+        node = node->next;
+    }
+    return e_count;
 }
 
 /**

--- a/src/treetable.c
+++ b/src/treetable.c
@@ -65,7 +65,7 @@ void treetable_conf_init(TreeTableConf *conf)
     conf->mem_alloc  = malloc;
     conf->mem_calloc = calloc;
     conf->mem_free   = free;
-    conf->cmp        = cc_common_cmp_ptr;
+    conf->cmp        = NULL;
 }
 
 /**

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -28,6 +28,11 @@ int cmp(void const *e1, void const *e2)
     return 1;
 }
 
+int zero_if_ptr_eq(void const *e1, void const *e2)
+{
+    return !(e1 == e2);
+}
+
 void *copy(void *e1)
 {
     int *cp = (int *) malloc(sizeof(int));
@@ -176,10 +181,10 @@ TEST_C(ListTestsWithDefaults, ListIndexOf)
     list_add(list1, &d);
 
     size_t idx;
-    list_index_of(list1, &a, cc_common_cmp_ptr, &idx);
+    list_index_of(list1, &a, zero_if_ptr_eq, &idx);
     CHECK_EQUAL_C_INT(0, idx);
 
-    list_index_of(list1, &c, cc_common_cmp_ptr, &idx);
+    list_index_of(list1, &c, zero_if_ptr_eq, &idx);
     CHECK_EQUAL_C_INT(2, idx);
 };
 
@@ -266,14 +271,14 @@ TEST_C(ListTestsWithDefaults, ListZipIterAdd)
     }
 
     size_t index;
-    list_index_of(list1, "h", cc_common_cmp_ptr, &index);
+    list_index_of(list1, "h", zero_if_ptr_eq, &index);
 
     CHECK_EQUAL_C_INT(2, index);
 
-    list_index_of(list1, "i", cc_common_cmp_ptr, &index);
+    list_index_of(list1, "i", zero_if_ptr_eq, &index);
     CHECK_EQUAL_C_INT(2, index);
 
-    list_index_of(list1, "c", cc_common_cmp_ptr, &index);
+    list_index_of(list1, "c", zero_if_ptr_eq, &index);
     CHECK_EQUAL_C_INT(3, index);
 
     CHECK_EQUAL_C_INT(1, list_contains(list1, "h"));
@@ -349,10 +354,10 @@ TEST_C(ListTestsWithDefaults, ListZipIterReplace)
     }
 
     size_t index;
-    list_index_of(list1, "h", cc_common_cmp_ptr, &index);
+    list_index_of(list1, "h", zero_if_ptr_eq, &index);
     CHECK_EQUAL_C_INT(1, index);
 
-    list_index_of(list1, "i", cc_common_cmp_ptr, &index);
+    list_index_of(list1, "i", zero_if_ptr_eq, &index);
     CHECK_EQUAL_C_INT(1, index);
     CHECK_EQUAL_C_INT(1, list_contains(list1, "h"));
     CHECK_EQUAL_C_INT(1, list_contains(list2, "i"));


### PR DESCRIPTION
Fixes #121 

Note : I instantiated the `cmp` function of `treetable` to NULL.
The reason is that it should always be modified anyway.
- If the treetable is initliazed through `treetable_new`, the cmp function is modified.
- If the `TreeTableConf` is created by hand, the `cmp` has to be provided.

The only case where it isn't modified would be when someone initializes the treetable through `treetable_new_conf`, and provides a `TreeTableConf` that was created through `treetable_conf_init` and that would be very bad practice.
However, since it is possible, and as suggested before in #121, I can change that and initialize the `cmp` function to the `cc_common_cmp_str`.