### PR TITLE
Fix some tests in the list test suite

### DIFF
--- a/test/listTest.cpp
+++ b/test/listTest.cpp
@@ -32,7 +32,7 @@ TEST_C_WRAPPER(ListTestsListPrefilled, ListIterAdd);
 TEST_C_WRAPPER(ListTestsListPrefilled, ListIterRemove);
 TEST_C_WRAPPER(ListTestsListPrefilled, ListIterDescRemove);
 TEST_C_WRAPPER(ListTestsListPrefilled, ListIterDescAdd);
-TEST_C_WRAPPER(ListTestsListPrefilled, ListReverese);
+TEST_C_WRAPPER(ListTestsListPrefilled, ListReverse);
 TEST_C_WRAPPER(ListTestsListPrefilled, ListToArray);
 TEST_C_WRAPPER(ListTestsListPrefilled, ListSpliceAt);
 TEST_C_WRAPPER(ListTestsListPrefilled, ListSplice);

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -544,7 +544,7 @@ TEST_C(ListTestsListPrefilled, ListIterDescAdd)
     CHECK_EQUAL_C_INT(*a, *el);
 };
 
-TEST_C(ListTestsListPrefilled, ListReverese)
+TEST_C(ListTestsListPrefilled, ListReverse)
 {
     int *last_old;
     list_get_last(list1, (void*) &last_old);

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -479,7 +479,7 @@ TEST_C(ListTestsListPrefilled, ListIterRemove)
         }
     }
     CHECK_EQUAL_C_INT(3, list_size(list1));
-    CHECK_EQUAL_C_INT(CC_OK, list_contains(list1, rm));
+    CHECK_EQUAL_C_INT(0, list_contains(list1, rm));
 };
 
 TEST_C(ListTestsListPrefilled, ListIterDescRemove)

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -354,10 +354,10 @@ TEST_C(ListTestsWithDefaults, ListZipIterReplace)
     }
 
     size_t index;
-    list_index_of(list1, "h", zero_if_ptr_eq, &index);
+    CHECK_EQUAL_C_INT(CC_OK, list_index_of(list1, "h", zero_if_ptr_eq, &index));
     CHECK_EQUAL_C_INT(1, index);
 
-    list_index_of(list1, "i", zero_if_ptr_eq, &index);
+    CHECK_EQUAL_C_INT(CC_OK, list_index_of(list2, "i", zero_if_ptr_eq, &index));
     CHECK_EQUAL_C_INT(1, index);
     CHECK_EQUAL_C_INT(1, list_contains(list1, "h"));
     CHECK_EQUAL_C_INT(1, list_contains(list2, "i"));

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -271,14 +271,13 @@ TEST_C(ListTestsWithDefaults, ListZipIterAdd)
     }
 
     size_t index;
-    list_index_of(list1, "h", zero_if_ptr_eq, &index);
-
+    CHECK_EQUAL_C_INT(CC_OK, list_index_of(list1, "h", zero_if_ptr_eq, &index));
     CHECK_EQUAL_C_INT(2, index);
 
-    list_index_of(list1, "i", zero_if_ptr_eq, &index);
+    CHECK_EQUAL_C_INT(CC_OK, list_index_of(list2, "i", zero_if_ptr_eq, &index));
     CHECK_EQUAL_C_INT(2, index);
 
-    list_index_of(list1, "c", zero_if_ptr_eq, &index);
+    CHECK_EQUAL_C_INT(CC_OK, list_index_of(list1, "c", zero_if_ptr_eq, &index));
     CHECK_EQUAL_C_INT(3, index);
 
     CHECK_EQUAL_C_INT(1, list_contains(list1, "h"));

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -475,11 +475,11 @@ TEST_C(ListTestsListPrefilled, ListIterRemove)
     while (list_iter_next(&iter, (void*) &e) != CC_ITER_END) {
         if (*e == 3) {
             list_iter_remove(&iter, NULL);
-            free(e);
         }
     }
     CHECK_EQUAL_C_INT(3, list_size(list1));
     CHECK_EQUAL_C_INT(0, list_contains(list1, rm));
+    free(rm);
 };
 
 TEST_C(ListTestsListPrefilled, ListIterDescRemove)


### PR DESCRIPTION
There was a bug in the test for `list_zip_iter_replace`.
The second `list_index_of` call wasn't working because it was looking for the value in the wrong list. The return value of the function call wasn't checked to be `CC_OK`. Since the first call returned the same expected index and put it at the same address, the test was still passing.