### PR TITLE
Update cc_common.h

### DIFF
--- a/src/include/cc_common.h
+++ b/src/include/cc_common.h
@@ -64,6 +64,6 @@ enum cc_stat {
 
 int cc_common_cmp_str(const void *key1, const void *key2);
 
-#define CC_CMP_STRING  cc_common_cmp_str
+#define CC_CMP_STRING cc_common_cmp_str
 
 #endif /* COLLECTIONS_C_COMMON_H */


### PR DESCRIPTION
Applied format removed '  ' -> '  ' now it is aligned with INLINE, FORCE_INLINE