### PR TITLE
Fix #149: deque_remove_at error

### DIFF
--- a/src/cc_deque.c
+++ b/src/cc_deque.c
@@ -363,7 +363,7 @@ enum cc_stat cc_deque_remove_at(CC_Deque *deque, size_t index, void **out)
     const size_t f = deque->first & c;
     const size_t p = (deque->first + index) & c;
 
-    void *removed  = deque->buffer[index];
+    void *removed  = deque->buffer[p];
 
     if (index == 0)
         return cc_deque_remove_first(deque, out);


### PR DESCRIPTION
The deque_remove_at function was returning an incorrect element in certain situations. The correct element is the one at index "p"