### PR TITLE
Potential uninit memory access

### DIFF
--- a/src/cc_queue.c
+++ b/src/cc_queue.c
@@ -75,9 +75,9 @@ enum cc_stat cc_queue_new_conf(CC_QueueConf const * const conf, CC_Queue **q)
         return CC_ERR_ALLOC;
 
     CC_Deque *deque;
-    cc_deque_new_conf(conf, &deque);
+    enum cc_stat stat = cc_deque_new_conf(conf, &deque);
 
-    if (!deque) {
+    if (stat) {
         conf->mem_free(queue);
         return CC_ERR_ALLOC;
     }


### PR DESCRIPTION
`cc_queue_new_conf` calls `cc_deque_new_conf` with `&deque` as parameter.

However, in case of allocation error, `cc_deque_new_conf` may return early without executing the `*d = deque` statement at the end of the function, leaving the input parameter uninitialised.

Then, `deque` is checked in `cc_queue_new_conf`, but if allocation failed, it is not NULL, it is just uninitialised, leading to undefined behaviour.